### PR TITLE
[circuit]: Define the `build_merkle_tree()` in the `utils/merkle_tree_builder.nr`

### DIFF
--- a/circuits/src/main.nr
+++ b/circuits/src/main.nr
@@ -26,12 +26,12 @@ fn main(
     //let leaf_reconstructed = poseidon2::Poseidon2::hash([job_title_hash, skill_hashes[0], skill_hashes[1]], 3); // NOTE: This hashing method is "Pedersen Hash"
     //assert(leaf == leaf_reconstructed);
 
-    // @dev - Job Title (Each "commitment" will be a "Leaf" of the "Markle Tree")
+    // @dev - Job Title commitment, which each "commitment" will be a "Leaf" of the Job Title commitment "Markle Tree"
     let inputs_for_job_title_commitment: [Field; 1] = [job_career_and_skill_data.job_title_hash];
     let job_title_commitment: Field = pedersen_hash([job_career_and_skill_data.job_title_hash, secret]);
     assert(job_title_commitment == job_career_and_skill_data.job_title_commitment);
 
-    // @dev - Skills (Each "commitment" will be a "Leaf" of the "Markle Tree")
+    // @dev - Skills combined commitment, which each "commitment" will be a "Leaf" of the Skills combined commitment "Markle Tree"
     let inputs_for_skill_hashes: [Field; 4] = job_career_and_skill_data.skill_hashes;
     let skills_combined_hash: Field = pedersen_hash(inputs_for_skill_hashes);
     let skills_combined_commitment: Field = pedersen_hash([skills_combined_hash, secret]);
@@ -56,11 +56,9 @@ fn main(
 
     let expected_nullifier = poseidon2::Poseidon2::hash(inputs_for_nullifier, inputs_for_nullifier.len());
     println(f"expected_nullifier: {expected_nullifier}");
-
     assert(nullifier == expected_nullifier);
 
-    //nullifier
-    //(nullifier, nft_metadata_cid_hash)
+    // @dev - Return the revealed data
     RevealedData {
         nullifier,
         job_title_commitment,

--- a/circuits/src/utils.nr
+++ b/circuits/src/utils.nr
@@ -1,2 +1,3 @@
 pub mod converter_module; // [Path]: utils/converter_module.nr
 pub mod poseidon_hash_converter_for_nft_metadata_cid; // [Path]: utils/poseidon_hash_converter_for_nft_metadata_cid.nr
+pub mod merkle_tree_builder; // [Path]: utils/merkle_tree_builder.nr

--- a/circuits/src/utils/merkle_tree_builder.nr
+++ b/circuits/src/utils/merkle_tree_builder.nr
@@ -1,0 +1,16 @@
+pub fn build_merkle_tree() {
+    let commitment_0 = std::hash::pedersen_hash([1]);
+    let commitment_1 = std::hash::pedersen_hash([2]);
+    let commitment_2 = std::hash::pedersen_hash([3]);
+    let commitment_3 = std::hash::pedersen_hash([4]);
+
+    let left_branch = std::hash::pedersen_hash([commitment_0, commitment_1]);
+    let right_branch = std::hash::pedersen_hash([commitment_2, commitment_3]);
+
+    let root = std::hash::pedersen_hash([left_branch, right_branch]);
+
+    std::println("Merkle Tree:");
+    std::println([root]);
+    std::println([left_branch, right_branch]);
+    std::println([commitment_0, commitment_1, commitment_2, commitment_3]);
+}


### PR DESCRIPTION
# 【Noir】`Merkle Tree` and `"Commitment" Hash`

([PR](https://github.com/masaun/noir-zk-pharos/pull/2#issue-2991829035))

## Methods
- `compute_merkle_root()`：https://noir-lang.org/docs/noir/standard_library/merkle_trees/
- `pedersen_commitment()`：https://noir-lang.org/docs/noir/standard_library/cryptographic_primitives/hashes#pedersen_commitment

<br>

## Key Difference between a `Commitment` and (Noirmal) `Hash`

- `Commitment` <-> (Normal) `Hash`
   - `Commitment` must includes a **`"random"` value**. 🟣 
   - Hence, **`"any"`** `hashing` method can be used to generate a `commitment` hash. 👍
      (= Don't need to use only `pedersen_commitment()`)
      https://chatgpt.com/share/67fe03c2-4f60-8000-911d-c1cc38df6443
      <img width="735" alt="Screenshot 2025-04-15 at 15 59 10" src="https://github.com/user-attachments/assets/5a2b6a32-87b6-42b2-ad15-0d36160da0d8" />
     ↓
   - Hence, a `commitment` hash would includes a given `secret`. 🔴
     https://github.com/noir-lang/noir-examples/blob/master/foundry-voting/circuits/src/main.nr#L11
     <img width="1019" alt="Screenshot 2025-04-15 at 16 03 32" src="https://github.com/user-attachments/assets/ff875af9-d744-4d9b-b3d2-f8acba7c4127" />


<br>

## How to compose a `Merkle Tree`'s `Merkle Root`, `Leaf` (= `Branch`), `Commitment`

- i.e). In case of the following ZK circuit.
```noir
fn main(
    root: pub Field, // @dev - Merkle Root
    index: Field,
    hash_path: [Field; 2],
    secret: Field,   // @dev - a secret code that was distributed to each voter (before the voting starts)
    proposalId: pub Field,
    vote: pub Field
) -> pub Field {
    let note_commitment = std::hash::pedersen_hash([secret]);
    let nullifier = std::hash::pedersen_hash([root, secret, proposalId]);

    let check_root = std::merkle::compute_merkle_root(note_commitment, index, hash_path);
    assert(root == check_root);

    nullifier  // @dev - Return the nullifier -> Then, it will be stored on-chain so that it can be used to prevent double-spending.
}
```
↓
- Its `Merkle Tree`'s `Merkle Root`, `Leaf`, `Commitment` can be composed like this:
  https://github.com/noir-lang/noir-examples/blob/master/foundry-voting/circuits/src/main.nr#L27-L35
```noir
#[test]
fn test_valid_build_merkle_tree() {
    let commitment_0 = std::hash::pedersen_hash([1]); 🟣
    let commitment_1 = std::hash::pedersen_hash([2]); 🟣
    let commitment_2 = std::hash::pedersen_hash([3]); 🟣
    let commitment_3 = std::hash::pedersen_hash([4]); 🟣

    let left_branch = std::hash::pedersen_hash([commitment_0, commitment_1]); 🟣
    let right_branch = std::hash::pedersen_hash([commitment_2, commitment_3]); 🟣

    let root = std::hash::pedersen_hash([left_branch, right_branch]); 🟣

    let proposalId = 0;
    let vote = 1;

    let nullifier = main(root, 0, [commitment_1, right_branch], 1, proposalId, vote);

    let expected_nullifier = std::hash::pedersen_hash([root, 1, proposalId]);

    std::println("Merkle Tree:");
    std::println([root]); ⭐️
    std::println([left_branch, right_branch]); ⭐️
    std::println([commitment_0, commitment_1, commitment_2, commitment_3]); ⭐️

    assert(nullifier == expected_nullifier);
}
```
